### PR TITLE
Initialize package with placeholder translation and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # ai-thai
+
+ai-thai is an experimental Thai language learning toolkit. It currently
+provides a placeholder translation function and serves as a foundation for
+future development.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+```python
+import ai_thai
+print(ai_thai.translate("สวัสดี"))  # "สวัสดี"
+```

--- a/ai_thai/__init__.py
+++ b/ai_thai/__init__.py
@@ -1,0 +1,8 @@
+"""ai_thai package
+
+This package provides utilities for learning Thai.
+"""
+
+from .core import translate
+
+__all__ = ["translate"]

--- a/ai_thai/core.py
+++ b/ai_thai/core.py
@@ -1,0 +1,9 @@
+"""Core utilities for ai_thai."""
+
+def translate(text: str) -> str:
+    """Return a placeholder translation.
+
+    This function stands in for a real translation service. For now, it
+    simply echoes the provided text.
+    """
+    return text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ai-thai"
+version = "0.1.0"
+description = "Experimental Thai language learning toolkit"
+authors = [{name = "AI"}]
+readme = "README.md"
+requires-python = ">=3.8"

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,5 @@
+"""Smoke tests for ai_thai."""
+
+def test_import():
+    import ai_thai
+    assert hasattr(ai_thai, "translate")


### PR DESCRIPTION
## Summary
- add `ai_thai` package with placeholder translation utility
- document installation and usage in README with newline fix
- configure packaging and basic smoke test

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964c84e638833180b3502d7349b4ad